### PR TITLE
CDITCK-384  Create tests for observer method invocation context

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Foo.java
@@ -1,0 +1,4 @@
+package org.jboss.cdi.tck.tests.event.observer.context;
+
+public class Foo {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/FooObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/FooObserver.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+import javax.ejb.EJB;
+import javax.enterprise.event.Observes;
+import javax.enterprise.event.TransactionPhase;
+import javax.naming.InitialContext;
+import javax.transaction.TransactionSynchronizationRegistry;
+
+import org.jboss.cdi.tck.util.ActionSequence;
+
+public class FooObserver {
+
+    @EJB
+    private Toner toner;
+
+    @EJB
+    private Printer printer;
+
+    private static TransactionSynchronizationRegistry tsr;
+    
+    public void observeInProgress(@Observes(during = TransactionPhase.IN_PROGRESS) Foo foo) throws Exception {
+        // this observer method is called first and we do not have to look up TransactionSynchronizationRegistry each time
+        if (tsr == null) {
+            tsr = (TransactionSynchronizationRegistry) InitialContext.doLookup("java:comp/TransactionSynchronizationRegistry");
+        }
+        assertEquals(tsr.getTransactionKey(), Printer.getKey(),
+                "Non-transactional observer method was NOT called in the same transaction context as the invocation of Event.fire()");
+        assertClientSecurityContext(TransactionPhase.IN_PROGRESS);
+    }
+
+    public void observeBeforeCompletion(@Observes(during = TransactionPhase.BEFORE_COMPLETION) Foo foo) throws Exception {
+        assertEquals(tsr.getTransactionKey(), Printer.getKey(),
+                "Before completion transactional observer method was NOT called within the context of the transaction that was about to complete.");
+        assertClientSecurityContext(TransactionPhase.BEFORE_COMPLETION);
+    }
+
+    public void observeAfterCompletion(@Observes(during = TransactionPhase.AFTER_COMPLETION) Foo foo) throws Exception {
+        assertClientSecurityContext(TransactionPhase.AFTER_COMPLETION);
+    }
+
+    public void observeAfterFailure(@Observes(during = TransactionPhase.AFTER_FAILURE) Foo foo) throws Exception {
+        assertClientSecurityContext(TransactionPhase.AFTER_FAILURE);
+    }
+
+    public void observeAfterSuccess(@Observes(during = TransactionPhase.AFTER_SUCCESS) Foo foo) throws Exception {
+        assertClientSecurityContext(TransactionPhase.AFTER_SUCCESS);
+    }
+
+    private void assertClientSecurityContext(TransactionPhase phase) {
+
+        toner.spill();
+        try {
+            printer.tryAccess();
+            fail("Transactional observer method was NOT called within the same client security context.");
+        } catch (javax.ejb.EJBAccessException expected) {
+            // OK
+        }
+
+        ActionSequence.addAction(phase.toString());
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/ObserverMethodInvocationContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/ObserverMethodInvocationContextTest.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context;
+
+import static org.jboss.cdi.tck.TestGroups.JAVAEE_FULL;
+import static org.jboss.cdi.tck.TestGroups.PERSISTENCE;
+import static org.jboss.cdi.tck.cdi.Sections.OBSERVER_METHOD_INVOCATION_CONTEXT;
+
+import javax.enterprise.event.TransactionPhase;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.cdi.tck.util.ActionSequence;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+/**
+ * @author Matus Abaffy
+ */
+@SpecVersion(spec = "cdi", version = "1.1 Final Release")
+public class ObserverMethodInvocationContextTest extends AbstractTest {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClassPackage(ObserverMethodInvocationContextTest.class)
+                .withDefaultPersistenceXml()
+                .build();
+    }
+
+    @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER, groups = { PERSISTENCE, JAVAEE_FULL })
+    @SpecAssertions({ @SpecAssertion(section = OBSERVER_METHOD_INVOCATION_CONTEXT, id = "a"),
+            @SpecAssertion(section = OBSERVER_METHOD_INVOCATION_CONTEXT, id = "b"),
+            @SpecAssertion(section = OBSERVER_METHOD_INVOCATION_CONTEXT, id = "c") })
+    public void testTransactionalObserverMethod(Student student) throws Exception {
+        ActionSequence.reset();
+
+        student.printSuccess();
+        student.printFailure();
+
+        // Checking transaction and client security context is done in FooObserver
+        ActionSequence.assertSequenceDataContainsAll(TransactionPhase.IN_PROGRESS.toString(),
+                TransactionPhase.BEFORE_COMPLETION.toString(), TransactionPhase.AFTER_COMPLETION.toString(),
+                TransactionPhase.AFTER_SUCCESS.toString(), TransactionPhase.AFTER_FAILURE.toString());
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Printer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Printer.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context;
+
+import javax.annotation.Resource;
+import javax.annotation.security.RolesAllowed;
+import javax.annotation.security.RunAs;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
+
+@Stateless
+@RunAs("printer")
+@RolesAllowed("student")
+@TransactionManagement(TransactionManagementType.BEAN)
+public class Printer {
+
+    @EJB
+    private Toner toner;
+
+    @Resource
+    private TransactionSynchronizationRegistry tsr;
+
+    @Resource
+    private UserTransaction userTransaction;
+
+    @Inject
+    Event<Foo> event;
+
+    private static Object key;
+
+    public static Object getKey() {
+        return key;
+    }
+
+    public void printSuccess() throws Exception {
+        userTransaction.begin();
+
+        // we need to set the key before firing an event as the observer checks for equality
+        key = tsr.getTransactionKey();
+
+        toner.spill();
+        event.fire(new Foo());
+
+        userTransaction.commit();
+    }
+
+    public void printFailure() throws Exception {
+        userTransaction.begin();
+
+        // we need to set the key before firing an event as the observer checks for equality
+        key = tsr.getTransactionKey();
+
+        toner.spill();
+        event.fire(new Foo());
+
+        userTransaction.rollback();
+    }
+
+    public void tryAccess() {
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Student.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Student.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context;
+
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RunAs;
+import javax.ejb.EJB;
+import javax.ejb.Stateful;
+
+@Stateful
+@RunAs("student")
+@PermitAll
+public class Student {
+
+    @EJB
+    private Printer printer;
+
+    public void printSuccess() throws Exception {
+        printer.printSuccess();
+    }
+
+    public void printFailure() throws Exception {
+        printer.printFailure();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Toner.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/Toner.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.Stateless;
+
+@Stateless
+@RolesAllowed("printer")
+public class Toner {
+
+    public void spill() {
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Foo.java
@@ -1,0 +1,4 @@
+package org.jboss.cdi.tck.tests.event.observer.context.enterprise;
+
+public class Foo {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/FooObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/FooObserver.java
@@ -1,0 +1,106 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context.enterprise;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import javax.annotation.Resource;
+import javax.annotation.security.DeclareRoles;
+import javax.ejb.EJB;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+import javax.enterprise.event.Observes;
+import javax.enterprise.event.TransactionPhase;
+import javax.naming.InitialContext;
+import javax.transaction.TransactionSynchronizationRegistry;
+
+import org.jboss.cdi.tck.util.ActionSequence;
+
+@Stateless
+@DeclareRoles({ "student", "printer" })
+public class FooObserver implements ObserverLocal {
+
+    @EJB
+    private Toner toner;
+
+    @EJB
+    private Printer printer;
+
+    @Resource
+    private SessionContext sc;
+
+    private static TransactionSynchronizationRegistry tsr;
+
+    @Override
+    public void observeInProgress(@Observes(during = TransactionPhase.IN_PROGRESS) Foo foo) throws Exception {
+        // this observer method is called first and we do not have to look up TransactionSynchronizationRegistry each time
+        if (tsr == null) {
+            tsr = (TransactionSynchronizationRegistry) InitialContext.doLookup("java:comp/TransactionSynchronizationRegistry");
+        }
+        assertEquals(tsr.getTransactionKey(), Printer.getKey(),
+                "Non-transactional observer method was NOT called in the same transaction context as the invocation of Event.fire()");
+        assertClientSecurityContext(TransactionPhase.IN_PROGRESS);
+    }
+
+    @Override
+    public void observeBeforeCompletion(@Observes(during = TransactionPhase.BEFORE_COMPLETION) Foo foo) throws Exception {
+        assertEquals(tsr.getTransactionKey(), Printer.getKey(),
+                "Before completion transactional observer method was NOT called within the context of the transaction that was about to complete.");
+        assertClientSecurityContext(TransactionPhase.BEFORE_COMPLETION);
+    }
+
+    @Override
+    public void observeAfterCompletion(@Observes(during = TransactionPhase.AFTER_COMPLETION) Foo foo) throws Exception {
+        assertClientSecurityContext(TransactionPhase.AFTER_COMPLETION);
+    }
+
+    @Override
+    public void observeAfterFailure(@Observes(during = TransactionPhase.AFTER_FAILURE) Foo foo) throws Exception {
+        assertClientSecurityContext(TransactionPhase.AFTER_FAILURE);
+    }
+
+    @Override
+    public void observeAfterSuccess(@Observes(during = TransactionPhase.AFTER_SUCCESS) Foo foo) throws Exception {
+        assertClientSecurityContext(TransactionPhase.AFTER_SUCCESS);
+    }
+
+    private void assertClientSecurityContext(TransactionPhase phase) {
+        // TODO is using injected SC correct? no need to look it up before checking security context?
+        // EJBContext sc;
+        // try {
+        // sc = (EJBContext) InitialContext.doLookup("java:comp/EJBContext");
+        // } catch (NamingException e) {
+        // throw new RuntimeException(e);
+        // }
+
+        // both fail - see WFLY-2847
+        assertTrue(sc.isCallerInRole("student"));
+        assertTrue(!sc.isCallerInRole("printer"));
+
+        toner.spill();
+        try {
+            printer.tryAccess();
+            fail("Transactional observer method was NOT called within the same client security context.");
+        } catch (javax.ejb.EJBAccessException expected) {
+            // OK
+        }
+
+        ActionSequence.addAction(phase.toString());
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/ObserverLocal.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/ObserverLocal.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context.enterprise;
+
+import javax.ejb.Local;
+
+@Local
+public interface ObserverLocal {
+
+    public void observeInProgress(Foo foo) throws Exception;
+
+    public void observeBeforeCompletion(Foo foo) throws Exception;
+
+    public void observeAfterCompletion(Foo foo) throws Exception;
+
+    public void observeAfterFailure(Foo foo) throws Exception;
+
+    public void observeAfterSuccess(Foo foo) throws Exception;
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Printer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Printer.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context.enterprise;
+
+import javax.annotation.Resource;
+import javax.annotation.security.RolesAllowed;
+import javax.annotation.security.RunAs;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
+
+@Stateless
+@RunAs("printer")
+@RolesAllowed("student")
+@TransactionManagement(TransactionManagementType.BEAN)
+public class Printer {
+
+    @EJB
+    private Toner toner;
+
+    @Resource
+    private TransactionSynchronizationRegistry tsr;
+
+    @Resource
+    private UserTransaction userTransaction;
+
+    @Inject
+    Event<Foo> event;
+
+    private static Object key;
+
+    public static Object getKey() {
+        return key;
+    }
+
+    public void printSuccess() throws Exception {
+        userTransaction.begin();
+
+        // we need to set the key before firing an event as the observer checks for equality
+        key = tsr.getTransactionKey();
+
+        toner.spill();
+        event.fire(new Foo());
+
+        userTransaction.commit();
+    }
+
+    public void printFailure() throws Exception {
+        userTransaction.begin();
+
+        // we need to set the key before firing an event as the observer checks for equality
+        key = tsr.getTransactionKey();
+
+        toner.spill();
+        event.fire(new Foo());
+
+        userTransaction.rollback();
+    }
+
+    public void tryAccess() {
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/SessionBeanObserverMethodInvocationContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/SessionBeanObserverMethodInvocationContextTest.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context.enterprise;
+
+import static org.jboss.cdi.tck.TestGroups.JAVAEE_FULL;
+import static org.jboss.cdi.tck.TestGroups.PERSISTENCE;
+import static org.jboss.cdi.tck.cdi.Sections.OBSERVER_METHOD_INVOCATION_CONTEXT;
+
+import javax.enterprise.event.TransactionPhase;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.cdi.tck.util.ActionSequence;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+/**
+ * @author Matus Abaffy
+ */
+@SpecVersion(spec = "cdi", version = "1.1 Final Release")
+public class SessionBeanObserverMethodInvocationContextTest extends AbstractTest {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClassPackage(SessionBeanObserverMethodInvocationContextTest.class)
+                .withDefaultPersistenceXml()
+                .build();
+    }
+
+    @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER, groups = { PERSISTENCE, JAVAEE_FULL })
+    @SpecAssertions({ @SpecAssertion(section = OBSERVER_METHOD_INVOCATION_CONTEXT, id = "a"),
+            @SpecAssertion(section = OBSERVER_METHOD_INVOCATION_CONTEXT, id = "b"),
+            @SpecAssertion(section = OBSERVER_METHOD_INVOCATION_CONTEXT, id = "c") })
+    public void testTransactionalObserverMethod(Student student) throws Exception {
+        ActionSequence.reset();
+
+        student.printSuccess();
+        student.printFailure();
+
+        // Checking transaction and client security context is done in FooObserver
+        ActionSequence.assertSequenceDataContainsAll(TransactionPhase.IN_PROGRESS.toString(),
+                TransactionPhase.BEFORE_COMPLETION.toString(), TransactionPhase.AFTER_COMPLETION.toString(),
+                TransactionPhase.AFTER_SUCCESS.toString(), TransactionPhase.AFTER_FAILURE.toString());
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Student.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Student.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context.enterprise;
+
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RunAs;
+import javax.ejb.EJB;
+import javax.ejb.Stateful;
+
+@Stateful
+@RunAs("student")
+@PermitAll
+public class Student {
+
+    @EJB
+    private Printer printer;
+
+    public void printSuccess() throws Exception {
+        printer.printSuccess();
+    }
+
+    public void printFailure() throws Exception {
+        printer.printFailure();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Toner.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/Toner.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context.enterprise;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.Stateless;
+
+@Stateless
+@RolesAllowed("printer")
+public class Toner {
+
+    public void spill() {
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Foo.java
@@ -1,0 +1,4 @@
+package org.jboss.cdi.tck.tests.event.observer.context.enterprise.staticMethod;
+
+public class Foo {
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/FooObserver.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/FooObserver.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context.enterprise.staticMethod;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import javax.annotation.security.DeclareRoles;
+import javax.ejb.EJBContext;
+import javax.ejb.Stateless;
+import javax.enterprise.event.Observes;
+import javax.enterprise.event.TransactionPhase;
+import javax.naming.InitialContext;
+import javax.transaction.TransactionSynchronizationRegistry;
+
+import org.jboss.cdi.tck.util.ActionSequence;
+
+@Stateless
+@DeclareRoles({ "student", "printer" })
+public class FooObserver {
+
+    private static TransactionSynchronizationRegistry tsr;
+    private static EJBContext ejbContext;
+
+    private static Toner toner;
+    private static Printer printer;
+
+    public static void observeInProgress(@Observes(during = TransactionPhase.IN_PROGRESS) Foo foo) throws Exception {
+        // this observer method is called first -> it is sufficient to lookup the needed resources just once
+        if (tsr == null) {
+            init();
+        }
+
+        assertEquals(tsr.getTransactionKey(), Printer.getKey(),
+                "Non-transactional observer method was NOT called in the same transaction context as the invocation of Event.fire()");
+        assertClientSecurityContext(TransactionPhase.IN_PROGRESS);
+    }
+
+    private static void init() throws Exception {
+        tsr = (TransactionSynchronizationRegistry) InitialContext.doLookup("java:comp/TransactionSynchronizationRegistry");
+        ejbContext = (EJBContext) InitialContext.doLookup("java:comp/EJBContext");
+        toner = (Toner) InitialContext.doLookup("java:comp/Toner");
+        printer = (Printer) InitialContext.doLookup("java:comp/Printer");
+    }
+
+    public static void observeBeforeCompletion(@Observes(during = TransactionPhase.BEFORE_COMPLETION) Foo foo) throws Exception {
+        assertEquals(tsr.getTransactionKey(), Printer.getKey(),
+                "Before completion transactional observer method was NOT called within the context of the transaction that was about to complete.");
+        assertClientSecurityContext(TransactionPhase.BEFORE_COMPLETION);
+    }
+
+    public static void observeAfterCompletion(@Observes(during = TransactionPhase.AFTER_COMPLETION) Foo foo) throws Exception {
+        assertClientSecurityContext(TransactionPhase.AFTER_COMPLETION);
+    }
+
+    public static void observeAfterFailure(@Observes(during = TransactionPhase.AFTER_FAILURE) Foo foo) throws Exception {
+        assertClientSecurityContext(TransactionPhase.AFTER_FAILURE);
+    }
+
+    public static void observeAfterSuccess(@Observes(during = TransactionPhase.AFTER_SUCCESS) Foo foo) throws Exception {
+        assertClientSecurityContext(TransactionPhase.AFTER_SUCCESS);
+    }
+
+    private static void assertClientSecurityContext(TransactionPhase phase) {
+        assertTrue(ejbContext.isCallerInRole("student"));
+        assertTrue(!ejbContext.isCallerInRole("printer"));
+
+        toner.spill();
+        try {
+            printer.tryAccess();
+            fail("Transactional observer method was NOT called within the same client security context.");
+        } catch (javax.ejb.EJBAccessException expected) {
+            // OK
+        }
+
+        ActionSequence.addAction(phase.toString());
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Printer.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Printer.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context.enterprise.staticMethod;
+
+import javax.annotation.Resource;
+import javax.annotation.security.RolesAllowed;
+import javax.annotation.security.RunAs;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
+
+@Stateless
+@RunAs("printer")
+@RolesAllowed("student")
+@TransactionManagement(TransactionManagementType.BEAN)
+public class Printer {
+
+    @EJB
+    private Toner toner;
+
+    @Resource
+    private TransactionSynchronizationRegistry tsr;
+
+    @Resource
+    private UserTransaction userTransaction;
+
+    @Inject
+    Event<Foo> event;
+
+    private static Object key;
+
+    public static Object getKey() {
+        return key;
+    }
+
+    public void printSuccess() throws Exception {
+        userTransaction.begin();
+
+        // we need to set the key before firing an event as the observer checks for equality
+        key = tsr.getTransactionKey();
+
+        toner.spill();
+        event.fire(new Foo());
+
+        userTransaction.commit();
+    }
+
+    public void printFailure() throws Exception {
+        userTransaction.begin();
+
+        // we need to set the key before firing an event as the observer checks for equality
+        key = tsr.getTransactionKey();
+
+        toner.spill();
+        event.fire(new Foo());
+
+        userTransaction.rollback();
+    }
+
+    public void tryAccess() {
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/SessionBeanStaticObserverMethodInvocationContextTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/SessionBeanStaticObserverMethodInvocationContextTest.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context.enterprise.staticMethod;
+
+import static org.jboss.cdi.tck.TestGroups.JAVAEE_FULL;
+import static org.jboss.cdi.tck.TestGroups.PERSISTENCE;
+import static org.jboss.cdi.tck.cdi.Sections.OBSERVER_METHOD_INVOCATION_CONTEXT;
+
+import javax.enterprise.event.TransactionPhase;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
+import org.jboss.cdi.tck.util.ActionSequence;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecAssertions;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+/**
+ * @author Matus Abaffy
+ */
+@SpecVersion(spec = "cdi", version = "1.1 Final Release")
+public class SessionBeanStaticObserverMethodInvocationContextTest extends AbstractTest {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClassPackage(SessionBeanStaticObserverMethodInvocationContextTest.class)
+                .withDefaultPersistenceXml()
+                .build();
+    }
+
+    @Test(dataProvider = ARQUILLIAN_DATA_PROVIDER, groups = { PERSISTENCE, JAVAEE_FULL })
+    @SpecAssertions({ @SpecAssertion(section = OBSERVER_METHOD_INVOCATION_CONTEXT, id = "a"),
+            @SpecAssertion(section = OBSERVER_METHOD_INVOCATION_CONTEXT, id = "b"),
+            @SpecAssertion(section = OBSERVER_METHOD_INVOCATION_CONTEXT, id = "c") })
+    public void testTransactionalObserverMethod(Student student) throws Exception {
+        ActionSequence.reset();
+
+        student.printSuccess();
+        student.printFailure();
+
+        // Checking transaction and client security context is done in FooObserver
+        ActionSequence.assertSequenceDataContainsAll(TransactionPhase.IN_PROGRESS.toString(),
+                TransactionPhase.BEFORE_COMPLETION.toString(), TransactionPhase.AFTER_COMPLETION.toString(),
+                TransactionPhase.AFTER_SUCCESS.toString(), TransactionPhase.AFTER_FAILURE.toString());
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Student.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Student.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context.enterprise.staticMethod;
+
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RunAs;
+import javax.ejb.EJB;
+import javax.ejb.Stateful;
+
+@Stateful
+@RunAs("student")
+@PermitAll
+public class Student {
+
+    @EJB
+    private Printer printer;
+
+    public void printSuccess() throws Exception {
+        printer.printSuccess();
+    }
+
+    public void printFailure() throws Exception {
+        printer.printFailure();
+    }
+}

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Toner.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/context/enterprise/staticMethod/Toner.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.cdi.tck.tests.event.observer.context.enterprise.staticMethod;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.Stateless;
+
+@Stateless
+@RolesAllowed("printer")
+public class Toner {
+
+    public void spill() {
+    }
+}

--- a/impl/src/main/resources/tck-audit-cdi.xml
+++ b/impl/src/main/resources/tck-audit-cdi.xml
@@ -5863,19 +5863,19 @@
     </section>
 
     <section id="observer_method_invocation_context" title="Observer method invocation context" level="3">
-        <assertion id="ba">
+        <assertion id="a">
             <text>If the observer method is a before completion transactional observer method, it is called within the context of the transaction that is about to complete and with the same client security context and lifecycle contexts.</text>
         </assertion>
 
-        <assertion id="c">
+        <assertion id="b">
             <text>If the observer method is any other kind of transactional observer method, it is called in an unspecified transaction context, but with the same client security context and lifecycle contexts as the transaction that just completed.</text>
         </assertion>
 
-        <assertion id="da">
+        <assertion id="c">
             <text>If an observer method is not a before completion transactional method, and not any other kind of transactional observer method, then the observer method is called in the same transaction context, client security context and lifecycle contexts as the invocation of |Event.fire()| or |BeanManager.fireEvent()|.</text>
         </assertion>
 
-        <assertion id="e">
+        <assertion id="d">
             <text>The transaction and security contexts for a business method of a session bean also depend upon the transaction attribute and |@RunAs| descriptor, if any.</text>
         </assertion>
     </section>


### PR DESCRIPTION
Currently, SessionBeanObserverMethodInvocationContextTest fails due to WFLY-2847.

Before merging, also check comments in org.jboss.cdi.tck.tests.event.observer.context.enterprise.FooObserver - whether SessionContext injected into observer is enough to check isCallerInRole(...)