### PR TITLE
BootstrapSEContainerTest - use try-with-resources for CDI

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BootstrapSEContainerTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/se/container/BootstrapSEContainerTest.java
@@ -100,11 +100,11 @@ public class BootstrapSEContainerTest extends Arquillian {
         params.put(IMPLICIT_SCAN_KEY, Boolean.TRUE);
 
         CDIProvider cdiProvider = CDI.getCDIProvider();
-        CDI<Object> cdi = cdiProvider.initialize(params);
-        Bar bar = cdi.select(Bar.class).get();
-        Assert.assertNotNull(bar);
-        bar.ping();
-        cdi.shutdown();
+        try (CDI<Object> cdi = cdiProvider.initialize(params)) {
+            Bar bar = cdi.select(Bar.class).get();
+            Assert.assertNotNull(bar);
+            bar.ping();
+        }
     }
 
 }


### PR DESCRIPTION
We'll need to use try-with-resources or try/finally almost everywhere. Otherwise,
when a test fails the CDI container is not shut down and interferes with other test methods.