### PR TITLE
Expand test for Conversation when invalidating session. Removed TODOs…

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/conversation/InvalidatingSessionDestroysConversationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/conversation/InvalidatingSessionDestroysConversationTest.java
@@ -50,7 +50,8 @@ public class InvalidatingSessionDestroysConversationTest extends AbstractConvers
 
     @Test
     @SpecAssertion(section = CONVERSATION_CONTEXT_EE, id = "qa")
-    // TODO this test doesn't precisely probe the boundaries of the service() method
+    // Doesn't precisely probe the boundaries of the service() method, rather tests that the conversation
+    // is eventually destroyed.
     public void testInvalidatingSessionDestroysConversation() throws Exception {
 
         WebClient webClient = new WebClient();

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/conversation/servlet/Message.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/conversation/servlet/Message.java
@@ -18,7 +18,11 @@ package org.jboss.cdi.tck.tests.context.conversation.servlet;
 
 import java.io.Serializable;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.ConversationScoped;
+
+import org.jboss.cdi.tck.util.ActionSequence;
 
 @ConversationScoped
 @SuppressWarnings("serial")
@@ -32,5 +36,15 @@ public class Message implements Serializable {
 
     public void setValue(String value) {
         this.value = value;
+    }
+    
+    @PostConstruct
+    public void init() {
+        ActionSequence.addAction("conversationCreated");
+    }
+    
+    @PreDestroy
+    public void destroy() {
+        ActionSequence.addAction("conversationDestroyed");
     }
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/conversation/servlet/Servlet.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/conversation/servlet/Servlet.java
@@ -27,6 +27,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.jboss.cdi.tck.util.ActionSequence;
+
 @SuppressWarnings("serial")
 @WebServlet("/servlet/*")
 public class Servlet extends HttpServlet {
@@ -52,8 +54,14 @@ public class Servlet extends HttpServlet {
             setMessage(req);
             printInfo(resp.getWriter());
         } else if (uri.endsWith("/invalidateSession")) {
+            ActionSequence.addAction("beforeInvalidate");
             req.getSession().invalidate();
+            ActionSequence.addAction("afterInvalidate");
             printInfo(resp.getWriter());
+        } else if (uri.endsWith("/resetSequence")) {
+            ActionSequence.reset();
+        } else if (uri.endsWith("/getSequence")) {
+            resp.getWriter().print(ActionSequence.getSequence().dataToCsv());
         } else {
             resp.setStatus(404);
         }


### PR DESCRIPTION
… regarding this

I modified test for conversation once the session is invalidated. This should precisely test when is the conversation destroyed. I also added another similar test with multiple conversation to verify similar behaviour for non-associated long-running conversations. Both tests should be relevant to CDI spec, chapter 6.7.4, TCK assertion qith id 'qa'
@tremes can you please review this?