### PR TITLE
Stabilize MessageDrivenBeanInterceptorInvocationTest.

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/MessageDrivenBeanInterceptorInvocationTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/MessageDrivenBeanInterceptorInvocationTest.java
@@ -20,6 +20,7 @@ import static org.jboss.cdi.tck.TestGroups.JAVAEE_FULL;
 import static org.jboss.cdi.tck.TestGroups.JMS;
 import static org.jboss.cdi.tck.cdi.Sections.BIZ_METHOD_EE;
 import static org.jboss.cdi.tck.shrinkwrap.descriptors.ejb.EjbJarDescriptorBuilder.MessageDriven.newMessageDriven;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.util.concurrent.TimeUnit;
@@ -31,8 +32,6 @@ import org.jboss.cdi.tck.AbstractTest;
 import org.jboss.cdi.tck.impl.ConfigurationFactory;
 import org.jboss.cdi.tck.shrinkwrap.WebArchiveBuilder;
 import org.jboss.cdi.tck.shrinkwrap.descriptors.ejb.EjbJarDescriptorBuilder;
-import org.jboss.cdi.tck.util.Timer;
-import org.jboss.cdi.tck.util.Timer.StopCondition;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
@@ -81,16 +80,8 @@ public class MessageDrivenBeanInterceptorInvocationTest extends AbstractTest {
 
         producer.sendQueueMessage();
 
-        // Wait for async processing
-        new Timer().setDelay(5, TimeUnit.SECONDS).addStopCondition(new StopCondition() {
-            @Override
-            public boolean isSatisfied() {
-                return MessageDrivenMissile.messageAccepted;
-            }
-        }).start();
-
-        assertTrue(MessageDrivenMissile.messageAccepted);
-        assertTrue(MissileInterceptor.methodIntercepted);
+        assertEquals(MessageDrivenMissile.class.getName(), MessageDrivenMissile.MESSAGES.poll(5, TimeUnit.SECONDS));
+        assertTrue(MissileInterceptor.METHOD_INTERCEPTED.get());
         assertTrue(MissileInterceptor.lifecycleCallbackIntercepted);
         assertTrue(MissileInterceptor.aroundConstructInterceptorCalled);
     }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/MessageDrivenMissile.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/MessageDrivenMissile.java
@@ -16,17 +16,19 @@
  */
 package org.jboss.cdi.tck.tests.interceptors.definition.enterprise.jms;
 
+import java.util.concurrent.LinkedBlockingDeque;
+
 import javax.jms.Message;
 import javax.jms.MessageListener;
 
 @Missile
 public class MessageDrivenMissile implements MessageListener {
 
-    public static boolean messageAccepted = false;
+    static final LinkedBlockingDeque<String> MESSAGES = new LinkedBlockingDeque<String>();
 
     @Override
     public void onMessage(Message message) {
-        messageAccepted = true;
+        MESSAGES.add(MessageDrivenMissile.class.getName());
     }
 
 }

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/MissileInterceptor.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/interceptors/definition/enterprise/jms/MissileInterceptor.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.cdi.tck.tests.interceptors.definition.enterprise.jms;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import javax.annotation.PostConstruct;
 import javax.interceptor.AroundConstruct;
 import javax.interceptor.AroundInvoke;
@@ -26,14 +28,14 @@ import javax.interceptor.InvocationContext;
 @Missile
 public class MissileInterceptor {
 
-    public static boolean methodIntercepted = false;
+    static final AtomicBoolean METHOD_INTERCEPTED = new AtomicBoolean(false);
 
     public static boolean lifecycleCallbackIntercepted = false;
     public static boolean aroundConstructInterceptorCalled = false;
     
     @AroundInvoke
     public Object alwaysReturnThis(InvocationContext ctx) throws Exception {
-        methodIntercepted = true;
+        METHOD_INTERCEPTED.set(true);
         return ctx.proceed();
     }
     
@@ -56,7 +58,7 @@ public class MissileInterceptor {
     }
 
     public static void reset() {
-        methodIntercepted = false;
+        METHOD_INTERCEPTED.set(false);
         lifecycleCallbackIntercepted = false;
         aroundConstructInterceptorCalled = false;
     }


### PR DESCRIPTION
Came across a seemingly random failure of this test on some architecture. I suppose that might have been caused by race condition on a simple boolean value. Hence I turned it into LinkedBlockingQueue.
Similar was done with Weld test [here] (https://github.com/weld/core/commit/d429eaa88581ea1eb5c01100bcd7493e4edc9214).