### PR TITLE
CDITCK-520 TCK tests throw CNFE with JDK 9

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -117,6 +117,11 @@
 			<groupId>javax.persistence</groupId>
 			<artifactId>persistence-api</artifactId>
 		</dependency>
+        
+        	<dependency>
+            		<groupId>javax.xml.ws</groupId>
+            		<artifactId>jaxws-api</artifactId>
+        	</dependency>
 
 		<dependency>
 			<groupId>commons-httpclient</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
 		<el.api.version>2.2</el.api.version>
 		<jsf.api.version>2.1</jsf.api.version>
 		<resteasy.version>2.2.1.GA</resteasy.version>
+		<javax.xml.ws.api>2.2.11</javax.xml.ws.api>
 		<!-- Test tools/dependencies -->
 		<jboss.test.audit.version>1.1.1.Final</jboss.test.audit.version>
 		<testng.version>6.8.8</testng.version>
@@ -200,6 +201,12 @@
 				<artifactId>persistence-api</artifactId>
 				<version>${jpa.api.version}</version>
 			</dependency>
+            
+            		<dependency>
+                		<groupId>javax.xml.ws</groupId>
+                		<artifactId>jaxws-api</artifactId>
+                		<version>${javax.xml.ws.api}</version>
+            		</dependency>
 
 			<dependency>
 				<groupId>org.jboss.resteasy</groupId>


### PR DESCRIPTION
CDITCK-520 against 1.2 branch.
This  only adds the dependency it does not solve TCK 1.2 compatibility with JDK 9.
