### PR TITLE
CDITCK-609 ApplicationContextLifecycleEventObserverOrderingTest needs…

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/contextLifecycleEvent/ApplicationContextLifecycleEventObserverOrderingTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/contextLifecycleEvent/ApplicationContextLifecycleEventObserverOrderingTest.java
@@ -38,7 +38,7 @@ public class ApplicationContextLifecycleEventObserverOrderingTest extends Abstra
 
     @Deployment
     public static WebArchive createTestArchive() {
-        return new WebArchiveBuilder().withClass(ApplicationScopedObserver.class).withTestClass(ApplicationContextLifecycleEventObserverOrderingTest.class)
+        return new WebArchiveBuilder().withClasses(ApplicationScopedObserver.class, TestExtension.class).withTestClass(ApplicationContextLifecycleEventObserverOrderingTest.class)
                 .withExtension(TestExtension.class).build();
     }
 


### PR DESCRIPTION
… to deploy TestExtension to make sure ActionSequence will be reset before asserting anything.