### PR TITLE
CDITCK-619: Fix cdi-tck-ext-lib manifest

### DIFF
--- a/ext-lib/src/main/resources/META-INF/MANIFEST.MF
+++ b/ext-lib/src/main/resources/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Specification-Vendor: Red Hat Middleware LLC
 Specification-Version: 1.0
 Implementation-Vendor-Id: org.jboss
 Implementation-Vendor: Red Hat Middleware LLC
-Implemenation-Version: 1.0
+Implementation-Version: 1.0

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/InstalledLibraryEarTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/InstalledLibraryEarTest.java
@@ -62,8 +62,8 @@ public class InstalledLibraryEarTest extends AbstractTest {
                 .attribute("Extension-List", "CDITCKExtLib")
                 .attribute("CDITCKExtLib-Extension-Name", "org.jboss.cdi.tck.extlib")
                 .attribute("CDITCKExtLib-Specification-Version", "1.0")
-                // .attribute("CDITCKExtLib-Implementation-Version", "1.0")
-                // .attribute("CDITCKExtLib-Implementation-Vendor-Id", "org.jboss")
+                .attribute("CDITCKExtLib-Implementation-Version", "1.0")
+                .attribute("CDITCKExtLib-Implementation-Vendor-Id", "org.jboss")
                 .exportAsString()));
 
         return enterpriseArchive;

--- a/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/InstalledLibraryWarTest.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/deployment/packaging/installedLibrary/InstalledLibraryWarTest.java
@@ -56,8 +56,8 @@ public class InstalledLibraryWarTest extends AbstractTest {
                                 .attribute("Extension-List", "CDITCKExtLib")
                                 .attribute("CDITCKExtLib-Extension-Name", "org.jboss.cdi.tck.extlib")
                                 .attribute("CDITCKExtLib-Specification-Version", "1.0")
-                                // .attribute("CDITCKExtLib-Implementation-Version", "1.0")
-                                // .attribute("CDITCKExtLib-Implementation-Vendor-Id", "org.jboss")
+                                .attribute("CDITCKExtLib-Implementation-Version", "1.0")
+                                .attribute("CDITCKExtLib-Implementation-Vendor-Id", "org.jboss")
                                 .exportAsString()));
     }
 


### PR DESCRIPTION
- also modify coressponding tests to specify impl version