### PR TITLE
Fix for issue 625 - backport for 2.0

### DIFF
--- a/impl/src/main/java/org/jboss/cdi/tck/tests/context/request/jaxrs/Foo.java
+++ b/impl/src/main/java/org/jboss/cdi/tck/tests/context/request/jaxrs/Foo.java
@@ -20,12 +20,15 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
+import java.util.concurrent.atomic.AtomicLong;
 
 @RequestScoped
 public class Foo {
 
     @Inject
     ObservingBean observingBean;
+
+    private static AtomicLong atomicLong = new AtomicLong(System.currentTimeMillis());
 
     private long id;
 
@@ -35,7 +38,7 @@ public class Foo {
 
     @PostConstruct
     public void init() {
-        this.id = System.currentTimeMillis();
+        this.id = atomicLong.getAndIncrement();
     }
 
     @PreDestroy

--- a/impl/src/main/resources/tck-tests.xml
+++ b/impl/src/main/resources/tck-tests.xml
@@ -38,6 +38,13 @@
                 </methods>
             </class>
 
+            <!-- CDITCK-625 -->
+            <class name="org.jboss.cdi.tck.tests.context.request.jaxrs.RequestContextTest">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+
         </classes>
     </test>
 


### PR DESCRIPTION
Use static atomic long to initialize id generator;

https://issues.jboss.org/browse/CDITCK-625
Signed-off-by: Doychin Bondzhev <doychin@dsoft-bg.com>